### PR TITLE
8924 topics hub

### DIFF
--- a/encyctng/encyclopedia/templates/encyclopedia/header.html
+++ b/encyctng/encyclopedia/templates/encyclopedia/header.html
@@ -2,7 +2,7 @@
     <div class="header__mobile-overlay" data-mobile-menu-overlay></div>
 
     <div class="header__wrapper">
-        <a href="/" class="header__home-link meta meta--large" aria-label="Densho Encyclopedia home">
+        <a href="/" class="header__home-link" aria-label="Densho Encyclopedia home">
             <svg class="header__logo" aria-hidden="true" focusable="false" >
                 <use xlink:href="#densho-logo"></use>
             </svg>

--- a/encyctng/encyclopedia/templates/patterns/components/topics/topics.html
+++ b/encyctng/encyclopedia/templates/patterns/components/topics/topics.html
@@ -2,8 +2,10 @@
 
 <div class="grid">
     <div class="topics mb-spacerHalf">
-        <h2 class="topics__title heading heading--three section-heading">{{ topics.title }}</h2>
+        {% if topics.title %}
+            <h2 class="topics__title heading heading--three section-heading">{{ topics.title }}</h2>
 
+        {% endif %}
         <div class="topics__items grid">
             {% for item in topics.items %}
                 <a href="{% if item.url %}{% pageurl item %}{% else %}#{% endif %}" class="topics__item">

--- a/encyctng/encyclopedia/templates/patterns/pages/collections/collections--a-z.html
+++ b/encyctng/encyclopedia/templates/patterns/pages/collections/collections--a-z.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load static %}
 
-{% block body_class %}template-collections{% endblock %}
+{% block body_class %}template-collections app--orange{% endblock %}
 
 {% block content %}
     {% include "patterns/components/collection_header/collection_header.html" with title="Collections" tags=tags tabs=tabs %}

--- a/encyctng/encyclopedia/templates/patterns/pages/collections/collections--authors.html
+++ b/encyctng/encyclopedia/templates/patterns/pages/collections/collections--authors.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load static %}
 
-{% block body_class %}template-collections{% endblock %}
+{% block body_class %}template-collections app--orange{% endblock %}
 
 {% block content %}
     {% include "patterns/components/collection_header/collection_header.html" with title="Collections" tags=tags tabs=tabs %}

--- a/encyctng/encyclopedia/templates/patterns/pages/collections/collections.html
+++ b/encyctng/encyclopedia/templates/patterns/pages/collections/collections.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load static %}
 
-{% block body_class %}template-collections{% endblock %}
+{% block body_class %}template-collections app--orange{% endblock %}
 
 {% block content %}
     {% include "patterns/components/collection_header/collection_header.html" with title="Collections" %}

--- a/encyctng/encyclopedia/templates/patterns/pages/home_page/home_page.html
+++ b/encyctng/encyclopedia/templates/patterns/pages/home_page/home_page.html
@@ -4,6 +4,12 @@
 {% block body_class %}template-homepage{% endblock %}
 
 {% block content %}
-    {% include "patterns/components/hero/hero.html" with hero=page.hero %}
-    {% include "patterns/components/topics/topics.html" with topics=page.topics %}
+    <div class="page">
+        <header class="page__header">
+            {% include "patterns/components/hero/hero.html" with hero=page.hero %}
+        </header>
+        <div class="page__content">
+            {% include "patterns/components/topics/topics.html" with topics=page.topics %}
+        </div>
+    </div>
 {% endblock content %}

--- a/encyctng/encyclopedia/templates/patterns/pages/home_page/home_page.html
+++ b/encyctng/encyclopedia/templates/patterns/pages/home_page/home_page.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load static %}
 
-{% block body_class %}template-homepage{% endblock %}
+{% block body_class %}template-homepage app--orange{% endblock %}
 
 {% block content %}
     <div class="page">

--- a/encyctng/encyclopedia/templates/patterns/pages/topic_listing/topic_listing.html
+++ b/encyctng/encyclopedia/templates/patterns/pages/topic_listing/topic_listing.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+{% load static encyclopedia_tags wagtailcore_tags wagtailimages_tags %}
+
+{% block body_class %}template-topics app--orange{% endblock %}
+
+{% block content %}
+<div class="page">
+    <header class="page__header page__header--padding grid">
+        <h1 class="page__title">{{ page.title }}</h1>
+        <div class="page__introduction intro">
+            {{ page.introduction }}
+        </div>
+    </header>
+    <div class="page__content">
+        {% include "patterns/components/topics/topics.html" with topics=page.topics %}
+    </div>
+</div>
+{% endblock content %}

--- a/encyctng/encyclopedia/templates/patterns/pages/topic_listing/topic_listing.yaml
+++ b/encyctng/encyclopedia/templates/patterns/pages/topic_listing/topic_listing.yaml
@@ -1,0 +1,52 @@
+context:
+  page:
+    title: Topics
+    introduction: Explore a rich collection of historical and cultural topics related to the Japanese American experience, incarceration during World War II, and beyond.
+    topics:
+      title: False
+      items:
+        - title: Arts
+          image: ''
+          articles: 453
+        - title: Camps
+          image: ''
+          articles: 453
+        - title: Chroniclers
+          image: ''
+          articles: 453
+        - title: Communities
+          image: ''
+          articles: 453
+        - title: Definitions
+          image: ''
+          articles: 453
+        - title: Events
+          image: ''
+          articles: 453
+        - title: Legal
+          image: ''
+          articles: 453
+        - title: Military
+          image: ''
+          articles: 453
+        - title: Newspapers
+          image: ''
+          articles: 453
+        - title: Organizations
+          image: ''
+          articles: 453
+        - title: People
+          image: ''
+          articles: 453
+        - title: Postwar
+          image: ''
+          articles: 453
+        - title: Prewar
+          image: ''
+          articles: 453
+        - title: Redress
+          image: ''
+          articles: 453
+        - title: Resettlement
+          image: ''
+          articles: 453

--- a/encyctng/static_src/sass/components/_app.scss
+++ b/encyctng/static_src/sass/components/_app.scss
@@ -1,0 +1,17 @@
+@use '../config' as *;
+
+.app {
+    $root: &;
+
+    &--orange {
+        #{$root}__header {
+            background-color: var(--color--orange);
+        }
+
+        &.template-topics {
+            #{$root}__content {
+                background-color: var(--color--orange);
+            }
+        }
+    }
+}

--- a/encyctng/static_src/sass/components/_hero.scss
+++ b/encyctng/static_src/sass/components/_hero.scss
@@ -133,15 +133,4 @@
         object-fit: cover;
         object-position: center;
     }
-
-    .template-homepage & {
-        position: relative;
-        top: -131px; // header height
-        margin-bottom: -131px;
-
-        @include media-query(large) {
-            top: -171px; // header height
-            margin-bottom: -171px;
-        }
-    }
 }

--- a/encyctng/static_src/sass/components/_page.scss
+++ b/encyctng/static_src/sass/components/_page.scss
@@ -1,6 +1,18 @@
 @use '../config' as *;
 
 .page {
+    $root: &;
+
+    &__header {
+        &--padding {
+            padding-top: 30px;
+
+            @include media-query(large) {
+                padding-top: 50px;
+            }
+        }
+    }
+
     &__section {
         border-top: 1px solid var(--color--lines);
         padding-bottom: $spacer-medium;
@@ -13,6 +25,26 @@
     &__content {
         &--border {
             border-top: 1px solid var(--color--lines);
+        }
+    }
+
+    &__introduction {
+        margin-bottom: $spacer-mini-plus;
+        max-width: $reading-column-max-width;
+
+        @include media-query(medium) {
+            margin-bottom: $spacer-medium;
+        }
+    }
+
+    .app--orange & {
+        #{$root}__header {
+            background-color: var(--color--orange);
+        }
+
+        #{$root}__title,
+        #{$root}__introduction {
+            color: var(--color--white);
         }
     }
 }

--- a/encyctng/static_src/sass/components/navigation/_header.scss
+++ b/encyctng/static_src/sass/components/navigation/_header.scss
@@ -123,9 +123,7 @@
         }
     }
 
-    .template-collections & {
-        background-color: var(--color--orange);
-
+    .app--orange & {
         #{$root}__wrapper {
             margin-bottom: 0;
         }

--- a/encyctng/static_src/sass/main.scss
+++ b/encyctng/static_src/sass/main.scss
@@ -11,6 +11,7 @@
 // Components
 @use 'components/article-listing-item';
 @use 'components/author-listing-item';
+@use 'components/app';
 @use 'components/button';
 @use 'components/carousel';
 @use 'components/carousel-control';


### PR DESCRIPTION
Topics hub template, named topic_listing to ensure no name conflicts with the topics.html component.

This also includes a refactor of how the orange header area works, we now have an app modifier app--orange which then gives the header and relevant page__heading areas the correct colours. 

Ticket: https://torchbox.monday.com/boards/1816002458/pulses/1864388924

URL: http://localhost:8082/pattern-library/render-pattern/patterns/pages/topic_listing/topic_listing.html
