### PR TITLE
Fix image rendering issues in article and author pages

### DIFF
--- a/encyctng/encyclopedia/templates/encyclopedia/author-detail.html
+++ b/encyctng/encyclopedia/templates/encyclopedia/author-detail.html
@@ -12,13 +12,10 @@
     {% endif %}
 
     {% load wagtailcore_tags wagtailimages_tags %}
-    <div class="author-listing-item__image-container">
-        {% image author.image fill-200x200 format-webp as image %}
-        <img class="author-listing-item__image" src="{{ image.url }}" alt="{{ image.alt }}" loading="lazy" width="{{ image.width }}" height="{{ image.height }}">
-    </div>
+    {% image author.image fill-200x200 format-webp class="author-listing-item__image" loading="lazy" %}
     <div class="author-listing-item__content">
         <p class="author-listing-item__description">{{ author.role }}</p>
-        <p>{{ author.description }}</p>
+        <div>{{ author.description|richtext }}</div>
     </div>
 
 

--- a/encyctng/static_src/sass/components/_article-listing-item.scss
+++ b/encyctng/static_src/sass/components/_article-listing-item.scss
@@ -32,7 +32,8 @@
         gap: $spacer-small;
     }
 
-    &__image-container {
+    &__image {
+        max-width: initial;
         width: 100px;
         height: 100px;
 
@@ -40,13 +41,6 @@
             width: 170px;
             height: 170px;
         }
-    }
-
-    &__image {
-        object-fit: cover;
-        object-position: center;
-        width: 100%;
-        height: 100%;
     }
 
     &__link {

--- a/encyctng/static_src/sass/components/_author-listing-item.scss
+++ b/encyctng/static_src/sass/components/_author-listing-item.scss
@@ -5,6 +5,15 @@
 
     &--standalone {
         max-width: 100%;
+
+        & + & {
+            margin-top: $spacer-small;
+        }
+    }
+
+    &--header {
+        max-width: 100%;
+        margin: $spacer-small 0;
     }
 
     &__heading {
@@ -14,21 +23,14 @@
     &__container {
         display: flex;
         flex-direction: row;
+        align-items: center;
         gap: $spacer-small;
     }
 
-    &__image-container {
+    &__image {
         width: 100px;
         height: 100px;
         border-radius: 50%;
-        overflow: hidden;
-    }
-
-    &__image {
-        object-fit: cover;
-        object-position: center;
-        width: 100%;
-        height: 100%;
     }
 
     &__link {
@@ -62,16 +64,8 @@
         margin-bottom: 0;
     }
 
-    &__description {
-        display: none;
-
-        @include media-query(large) {
-            display: block;
-        }
-    }
-
     .page__section & {
-        @include media-query(medium) {
+        @include media-query(large) {
             grid-column: 3 / span 6;
         }
     }

--- a/encyctng/static_src/sass/components/_full-width-image.scss
+++ b/encyctng/static_src/sass/components/_full-width-image.scss
@@ -8,15 +8,23 @@
             border-bottom: none;
         }
     }
+
     &__container {
         padding-bottom: $spacer-small;
         border-bottom: 2px solid var(--color--lines);
     }
 
+    &__wrapper {
+        container-type: inline-size;
+        background-color: var(--color--transparent-blue);
+    }
+
     &__image {
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
+        display: block;
+        // Add a maximum aspect ratio for tall images.
+        max-height: calc(100cqw * 3 / 4);
+        width: auto;
+        margin-inline: auto;
     }
 
     &__type {

--- a/encyctng/static_src/sass/config/_variables.scss
+++ b/encyctng/static_src/sass/config/_variables.scss
@@ -11,6 +11,7 @@ $color--orange: #ed6e58;
 $color--light-orange: #fce9e6;
 $color--dark-orange: #b94430;
 $color--transparent-orange: rgba(237, 110, 88, 0.15);
+$color--transparent-blue: rgba(40, 56, 81, 0.05);
 $color--transparent-white: rgba(255, 255, 255, 0.1);
 $color--border: #d4d7dc;
 $color--border-dark: #424e5f;
@@ -44,6 +45,7 @@ $color--border-dark: #424e5f;
     --color--light-orange: #{$color--light-orange};
     --color--dark-orange: #{$color--dark-orange};
     --color--transparent-orange: #{$color--transparent-orange};
+    --color--transparent-blue: #{$color--transparent-blue};
 }
 
 // --------------------------------- Fonts ------------------------------------

--- a/encyctng/styleguide/templates/patterns/components/author_listing_item/author_listing_item.html
+++ b/encyctng/styleguide/templates/patterns/components/author_listing_item/author_listing_item.html
@@ -5,12 +5,7 @@
         <h2 class="author-listing-item__heading heading heading--three section-heading">Authored by</h2>
     {% endif %}
     <div class="author-listing-item__container">
-        <div class="author-listing-item__image-container">
-            {% image author.image fill-200x200 format-webp as image %}
-            <a class="author-listing-item__link" href="{{ author.get_absolute_url }}">
-                <img class="author-listing-item__image" src="{{ image.url }}" alt="{{ image.alt }}" loading="lazy" width="{{ image.width }}" height="{{ image.height }}">
-            </a>
-        </div>
+        {% image author.image fill-200x200 format-webp class="author-listing-item__image" loading="lazy" %}
         <div class="author-listing-item__content">
             <h3 class="author-listing-item__title heading heading--four">
                 <a class="author-listing-item__link" href="{{ author.get_absolute_url }}">
@@ -20,7 +15,7 @@
             </h3>
             <p class="author-listing-item__description">{{ author.role }}</p>
             {% if author.description %}
-                <p class="author-listing-item__description">{{ author.description }}</p>
+                <div class="author-listing-item__description">{{ author.description|richtext }}</div>
             {% endif %}
         </div>
     </div>

--- a/encyctng/styleguide/templates/patterns/components/full_width_image/full_width_image.html
+++ b/encyctng/styleguide/templates/patterns/components/full_width_image/full_width_image.html
@@ -2,8 +2,10 @@
 
 <div class="full-width-image{% if modifier %} full-width-image--{{ modifier }}{% endif %}">
     <div class="full-width-image__container meta meta--small">
-        {% image item.image width-1000 format-webp as image %}
-        <img class="full-width-image__image" src="{{ image.url }}" alt="{{ image.alt }}" loading="lazy" width="{{ image.width }}" height="{{ image.height }}">
+        <div class="full-width-image__wrapper">
+            {% image item.image width-1000 format-webp as image %}
+            <img class="full-width-image__image" src="{{ image.url }}" alt="{{ image.alt }}" loading="lazy" width="{{ image.width }}" height="{{ image.height }}">
+        </div>
         <p class="full-width-image__type">{{ item.type }}</p>
         <p class="full-width-image__caption">{{ item.caption }}</p>
         <button class="full-width-image__button meta meta--small" data-modal-trigger data-modal-id="modal-{{ item.modal.id }}" aria-label="View more information about this image">

--- a/encyctng/styleguide/templates/patterns/pages/article/article.html
+++ b/encyctng/styleguide/templates/patterns/pages/article/article.html
@@ -68,13 +68,17 @@
         </section>
     {% endif %}
 
-    {% for author in page.authors_all %}
-        <section class="page__section">
-            <div class="page__section-container grid">
-                {% include "patterns/components/author_listing_item/author_listing_item.html" with author=author modifier="standalone" %}
-            </div>
-        </section>
-    {% endfor %}
+    {% with authors=page.authors_all %}
+        {% if authors %}
+            <section class="page__section">
+                <div class="page__section-container grid">
+                    {% for author in authors %}
+                        {% include "patterns/components/author_listing_item/author_listing_item.html" with author=author modifier="standalone" %}
+                    {% endfor %}
+                </div>
+            </section>
+        {% endif %}
+    {% endwith %}
 
     {% if page.related_links %}
         <section class="page__section">

--- a/encyctng/styleguide/templates/patterns/pages/collections/collections--author.html
+++ b/encyctng/styleguide/templates/patterns/pages/collections/collections--author.html
@@ -8,7 +8,7 @@
 
     <div class="grid">
 
-        {% include "patterns/components/author_listing_item/author_listing_item.html" with author=author modifier="standalone" %}
+        {% include "patterns/components/author_listing_item/author_listing_item.html" with author=author modifier="header" %}
 
         {% if collections %}
             <div class="listing">


### PR DESCRIPTION
Addresses three separate issues, I chose to bundle this together but am happy to split if you prefer!

## [Vertical image height on article-detail #97](https://github.com/denshoproject/encyc-tng/issues/97)

I implemented this per the design of [one of the article variants in Figma](https://www.figma.com/design/Jyr0YI8aLr0VqTnOEycPqj/Densho?node-id=484-9137&t=y8JIVwoj5JvNBk96-1). Added a maximum aspect ratio that full-width images are displayed at, "pillarboxing" with a subtle blue-gray background.

The designs use an arbitrary aspect ratio a bit below 12:10. I chose to go with 4:3 to match the intention but with a more common "photography" ratio. Easily changed in the CSS if needed.

Here is what the resulting constraints look like, only affecting tall images:

<img width="500" height="1246" alt="Vertical image height on article-detail 97" src="https://github.com/user-attachments/assets/25990d21-d60d-493c-b4dd-994209efef7f" />
