### PR TITLE
Add a max aspect ratio for full-width images. Fix #97

### DIFF
--- a/encyctng/static_src/sass/components/_full-width-image.scss
+++ b/encyctng/static_src/sass/components/_full-width-image.scss
@@ -8,15 +8,23 @@
             border-bottom: none;
         }
     }
+
     &__container {
         padding-bottom: $spacer-small;
         border-bottom: 2px solid var(--color--lines);
     }
 
+    &__wrapper {
+        container-type: inline-size;
+        background-color: var(--color--transparent-blue);
+    }
+
     &__image {
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
+        display: block;
+        // Add a maximum aspect ratio for tall images.
+        max-height: calc(100cqw * 3 / 4);
+        width: auto;
+        margin-inline: auto;
     }
 
     &__type {

--- a/encyctng/static_src/sass/config/_variables.scss
+++ b/encyctng/static_src/sass/config/_variables.scss
@@ -11,6 +11,7 @@ $color--orange: #ed6e58;
 $color--light-orange: #fce9e6;
 $color--dark-orange: #b94430;
 $color--transparent-orange: rgba(237, 110, 88, 0.15);
+$color--transparent-blue: rgba(40, 56, 81, 0.05);
 $color--transparent-white: rgba(255, 255, 255, 0.1);
 $color--border: #d4d7dc;
 $color--border-dark: #424e5f;
@@ -44,6 +45,7 @@ $color--border-dark: #424e5f;
     --color--light-orange: #{$color--light-orange};
     --color--dark-orange: #{$color--dark-orange};
     --color--transparent-orange: #{$color--transparent-orange};
+    --color--transparent-blue: #{$color--transparent-blue};
 }
 
 // --------------------------------- Fonts ------------------------------------

--- a/encyctng/styleguide/templates/patterns/components/full_width_image/full_width_image.html
+++ b/encyctng/styleguide/templates/patterns/components/full_width_image/full_width_image.html
@@ -2,8 +2,10 @@
 
 <div class="full-width-image{% if modifier %} full-width-image--{{ modifier }}{% endif %}">
     <div class="full-width-image__container meta meta--small">
-        {% image item.image width-1000 format-webp as image %}
-        <img class="full-width-image__image" src="{{ image.url }}" alt="{{ image.alt }}" loading="lazy" width="{{ image.width }}" height="{{ image.height }}">
+        <div class="full-width-image__wrapper">
+            {% image item.image width-1000 format-webp as image %}
+            <img class="full-width-image__image" src="{{ image.url }}" alt="{{ image.alt }}" loading="lazy" width="{{ image.width }}" height="{{ image.height }}">
+        </div>
         <p class="full-width-image__type">{{ item.type }}</p>
         <p class="full-width-image__caption">{{ item.caption }}</p>
         <button class="full-width-image__button meta meta--small" data-modal-trigger data-modal-id="modal-{{ item.modal.id }}" aria-label="View more information about this image">


### PR DESCRIPTION
Fixes #97, by enforcing a maximum aspect ratio for full-width images.

I implemented this per the design of [one of the article variants in Figma](https://www.figma.com/design/Jyr0YI8aLr0VqTnOEycPqj/Densho?node-id=484-9137&t=y8JIVwoj5JvNBk96-1). Added a maximum aspect ratio that full-width images are displayed at, "pillarboxing" with a subtle blue-gray background.

The designs use an arbitrary aspect ratio a bit below 12:10. I chose to go with 4:3 to match the intention but with a more common "photography" ratio. Easily changed in the CSS if needed. The implementation is based on container queries, which have [pretty good browser support](https://caniuse.com/css-container-query-units). For unsupported browsers, the images just won’t be constrained in height.

Here is what the resulting constraints look like, only affecting tall images:

<img width="500" height="1246" alt="Vertical image height on article-detail 97" src="https://github.com/user-attachments/assets/25990d21-d60d-493c-b4dd-994209efef7f" />

---

I couldn’t find any other use of the specific background color in use here, so decided to add it based on existing conventions of the project.