### PR TITLE
Fix squashed article thumbnails in listings. Fix #171

### DIFF
--- a/encyctng/static_src/sass/components/_article-listing-item.scss
+++ b/encyctng/static_src/sass/components/_article-listing-item.scss
@@ -32,7 +32,8 @@
         gap: $spacer-small;
     }
 
-    &__image-container {
+    &__image {
+        max-width: initial;
         width: 100px;
         height: 100px;
 
@@ -40,13 +41,6 @@
             width: 170px;
             height: 170px;
         }
-    }
-
-    &__image {
-        object-fit: cover;
-        object-position: center;
-        width: 100%;
-        height: 100%;
     }
 
     &__link {


### PR DESCRIPTION
Fixes #171, making sure the images always render fully visible with their square aspect ratio. From the styles and templates, it seems clear the intention is to always display square images. And we’re using `fill` so the images are expected to crop server-side:

https://github.com/denshoproject/encyc-tng/blob/00a9edc4ed9a29c0a99cd3d64d12220049c739c0/encyctng/styleguide/templates/patterns/components/article_listing_item/article_listing_item.html#L6-L7

Sample rendering:

<img width="441" height="382" alt="171-article-thumbnails" src="https://github.com/user-attachments/assets/52db81fd-a35f-4e0e-876b-b5a0a2a3f613" />

This is the same on smaller viewports, though at a smaller thumbnail size (170x170 -> 100x100).