### PR TITLE
Fix author descriptions rendering, layout, spacing. Fix #93

### DIFF
--- a/encyctng/encyclopedia/templates/encyclopedia/author-detail.html
+++ b/encyctng/encyclopedia/templates/encyclopedia/author-detail.html
@@ -12,13 +12,10 @@
     {% endif %}
 
     {% load wagtailcore_tags wagtailimages_tags %}
-    <div class="author-listing-item__image-container">
-        {% image author.image fill-200x200 format-webp as image %}
-        <img class="author-listing-item__image" src="{{ image.url }}" alt="{{ image.alt }}" loading="lazy" width="{{ image.width }}" height="{{ image.height }}">
-    </div>
+    {% image author.image fill-200x200 format-webp class="author-listing-item__image" loading="lazy" %}
     <div class="author-listing-item__content">
         <p class="author-listing-item__description">{{ author.role }}</p>
-        <p>{{ author.description }}</p>
+        <div>{{ author.description|richtext }}</div>
     </div>
 
 

--- a/encyctng/static_src/sass/components/_author-listing-item.scss
+++ b/encyctng/static_src/sass/components/_author-listing-item.scss
@@ -5,6 +5,15 @@
 
     &--standalone {
         max-width: 100%;
+
+        & + & {
+            margin-top: $spacer-small;
+        }
+    }
+
+    &--header {
+        max-width: 100%;
+        margin: $spacer-small 0;
     }
 
     &__heading {
@@ -14,21 +23,14 @@
     &__container {
         display: flex;
         flex-direction: row;
+        align-items: center;
         gap: $spacer-small;
     }
 
-    &__image-container {
+    &__image {
         width: 100px;
         height: 100px;
         border-radius: 50%;
-        overflow: hidden;
-    }
-
-    &__image {
-        object-fit: cover;
-        object-position: center;
-        width: 100%;
-        height: 100%;
     }
 
     &__link {
@@ -62,16 +64,8 @@
         margin-bottom: 0;
     }
 
-    &__description {
-        display: none;
-
-        @include media-query(large) {
-            display: block;
-        }
-    }
-
     .page__section & {
-        @include media-query(medium) {
+        @include media-query(large) {
             grid-column: 3 / span 6;
         }
     }

--- a/encyctng/styleguide/templates/patterns/components/author_listing_item/author_listing_item.html
+++ b/encyctng/styleguide/templates/patterns/components/author_listing_item/author_listing_item.html
@@ -5,12 +5,7 @@
         <h2 class="author-listing-item__heading heading heading--three section-heading">Authored by</h2>
     {% endif %}
     <div class="author-listing-item__container">
-        <div class="author-listing-item__image-container">
-            {% image author.image fill-200x200 format-webp as image %}
-            <a class="author-listing-item__link" href="{{ author.get_absolute_url }}">
-                <img class="author-listing-item__image" src="{{ image.url }}" alt="{{ image.alt }}" loading="lazy" width="{{ image.width }}" height="{{ image.height }}">
-            </a>
-        </div>
+        {% image author.image fill-200x200 format-webp class="author-listing-item__image" loading="lazy" %}
         <div class="author-listing-item__content">
             <h3 class="author-listing-item__title heading heading--four">
                 <a class="author-listing-item__link" href="{{ author.get_absolute_url }}">
@@ -20,7 +15,7 @@
             </h3>
             <p class="author-listing-item__description">{{ author.role }}</p>
             {% if author.description %}
-                <p class="author-listing-item__description">{{ author.description }}</p>
+                <div class="author-listing-item__description">{{ author.description|richtext }}</div>
             {% endif %}
         </div>
     </div>

--- a/encyctng/styleguide/templates/patterns/pages/article/article.html
+++ b/encyctng/styleguide/templates/patterns/pages/article/article.html
@@ -68,13 +68,17 @@
         </section>
     {% endif %}
 
-    {% for author in page.authors_all %}
-        <section class="page__section">
-            <div class="page__section-container grid">
-                {% include "patterns/components/author_listing_item/author_listing_item.html" with author=author modifier="standalone" %}
-            </div>
-        </section>
-    {% endfor %}
+    {% with authors=page.authors_all %}
+        {% if authors %}
+            <section class="page__section">
+                <div class="page__section-container grid">
+                    {% for author in authors %}
+                        {% include "patterns/components/author_listing_item/author_listing_item.html" with author=author modifier="standalone" %}
+                    {% endfor %}
+                </div>
+            </section>
+        {% endif %}
+    {% endwith %}
 
     {% if page.related_links %}
         <section class="page__section">

--- a/encyctng/styleguide/templates/patterns/pages/collections/collections--author.html
+++ b/encyctng/styleguide/templates/patterns/pages/collections/collections--author.html
@@ -8,7 +8,7 @@
 
     <div class="grid">
 
-        {% include "patterns/components/author_listing_item/author_listing_item.html" with author=author modifier="standalone" %}
+        {% include "patterns/components/author_listing_item/author_listing_item.html" with author=author modifier="header" %}
 
         {% if collections %}
             <div class="listing">


### PR DESCRIPTION
Fixes #93. I spotted two more issues in addition to what was reported there:

- Author descriptions contain rich text, so need to be rendered with `|richtext`. And they can contain paragraph or heading tags so can’t be inside a `<p>`. I’ve made that change.
- Authors have no `role` field (see [Author model](https://github.com/denshoproject/encyc-tng/blob/develop/encyctng/editors/models.py#L12)). I assumed this was either to be added later, or a departure from the designs. Decided to keep the code as-is in that respect. There would be further work needed to either implement this or clean up the unneeded rendering code.

----

Back to the original list of issues, they had the same underlying cause across multiple templates so I tried to fix them in the same way everywhere. I did have to introduce a new `header` modifier for `author_listing_item.html`, to make sure that renders with the correct spacing for this use of authors’ display in a header area.

## authors-list

- [x] Author images squashed in full-width layout -- fixed similarly to #229 / #171
- [x] Author description missing in narrow layout

Tested with Collections - Authors by A-Z, with varying author configurations:

<img width="1188" height="714" alt="93-collections-a-z" src="https://github.com/user-attachments/assets/f25186c0-0a2d-4e7c-95f4-af8d30fc9c0a" />

## authors-detail

- [x] Author description missing in narrow layout
- [x] Author image squashed in full-width layout -- fixed similarly to #229 / #171
- [x] author missing vertical padding

I couldn’t find designs in Figma for this view but I believe the relevant fixes were simple to interpret:

<img width="1380" height="312" alt="93-single-author" src="https://github.com/user-attachments/assets/649ba67b-7134-45c9-8d88-59fcce001a10" />

## article

- [x] first author indented weirdly -- I don’t recall what this referred to but I believe I have fixed it(?), the alignment matches the designs in Figma.
- [x] author images squashed in full-width layout -- fixed similarly to #229 / #171
- [x] author descriptions missing from narrow layout
- [x] divider line at bottom of author should only display for last author in forloop

<img width="921" height="620" alt="93-article" src="https://github.com/user-attachments/assets/6af417ff-6708-44c6-9526-f0cfef516598" />
